### PR TITLE
Fix `build.sh`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-cargo run --release -- $1
-if [-f /lib/crt1.o]; then
+cargo run --release -- "$1"
+if [ -f /lib/crt1.o ]; then
     ld -o a /lib/crt1.o a.out -lc
-elif [-f /usr/lib32/crt1.o]; then
+elif [ -f /usr/lib32/crt1.o ]; then
     ld -o a /usr/lib32/crt1.o a.out -lc
 else
     echo "No crt1.o found"


### PR DESCRIPTION
This PR fixes some typos in `build.sh`. Unfortunately, on both my WSL2 machine and my M1 MacBook, even with the fixes it still fails with this error:

```
No crt1.o found
```